### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @joethorley


### PR DESCRIPTION
Adds `.github/CODEOWNERS` naming @joethorley as code owner of this fork). Assigned per operator instruction; tracking issue skipped as issues are disabled on this fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)